### PR TITLE
Documentation support for ARM64

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -2,7 +2,9 @@
 
 ## Install the guardian node
 
-Please follow the instructions below to download the lastest **Linux** binary and the necessary data. If you prefer to compile from the source code, please follow the steps [here](./COMPILE.md#install-guardian-node-from-source-code). If you are running the node on a Linux server, you'd need to run the node in a **screen or tmux** session, so that after you've logged off, the Theta node can continue to run.
+Please follow the instructions below to download the lastest **Linux** binary and the necessary data. If you prefer to compile from the source code, please follow the steps [here](./COMPILE.md#install-guardian-node-from-source-code). If you are using an ARM64-based device, please follow the steps [here](./COMPILE_ARM64.md#install-guardian-node-from-source-code).
+
+If you are running the node on a Linux server, you'd need to run the node in a **screen or tmux** session, so that after you've logged off, the Theta node can continue to run.
 
 ```
 screen -S theta_mainnet # if you run the node on a Linux server

--- a/docs/COMPILE_ARM64.md
+++ b/docs/COMPILE_ARM64.md
@@ -4,9 +4,9 @@ The script was tested on the following device:
 * Raspberry Pi OS 64 bits, Kernel Version 5.10, Debian version 11 (bullseye)
 * Raspberry Pi 4 4GB RAM
 
-## Install Go 1.14.2
+## Install Go 1.17.8
 
-Install Go and set environment variables `GOPATH` , `GOBIN`, and `PATH` following the commands below. The current code base should compile with **Go 1.14.2** on a ARM64 based architecture. Below are the steps to install Go 1.14.2 and setup the environments on Ubuntu.
+Install Go and set environment variables `GOPATH` , `GOBIN`, and `PATH` following the commands below. The current code base should compile with **Go 1.17.8** on a ARM64 based architecture. Below are the steps to install Go 1.17.8 and setup the environments on Ubuntu.
 
 ```
 sudo apt-get update
@@ -14,8 +14,8 @@ sudo apt-get install build-essential
 sudo apt-get install gcc
 sudo apt-get install make
 sudo apt install libstdc++-9-dev
-sudo wget https://go.dev/dl/go1.14.2.linux-arm64.tar.gz
-sudo tar -C /usr/local -xzf go1.14.2.linux-arm64.tar.gz
+sudo wget https://go.dev/dl/go1.17.8.linux-arm64.tar.gz
+sudo tar -C /usr/local -xzf go1.17.8.linux-arm64.tar.gz
 echo 'export GOROOT=/usr/local/go' >> ~/.bashrc
 echo 'export GOPATH=$HOME/go' >> ~/.bashrc
 echo 'export PATH=$PATH:$GOROOT/bin:$GOPATH/bin' >> ~/.bashrc
@@ -36,10 +36,12 @@ Then, we have to fix the package dependences for ARM64:
 # Fix Go dependences
 cd $THETA_HOME
 sed 's/v0.0.0-20200107021104-147ed25f233e/v0.0.0-20220216073600-600054663ec1/' go.mod > aux_file
-sed 's/github.com\/wedeploy\/gosocketio v0.0.7-beta/github.com\/googollee\/go-socket.io v1.6.1/' aux_file > aux_file2
+sed 's/github.com\/wedeploy\/gosocketio v0.0.7-beta/github.com\/cih-y2k\/wedeploy-gosocketio v0.0.8/' aux_file > aux_file2
 rm go.mod
 cp aux_file2 go.mod
 rm aux_file aux_file2
+go mod download github.com/cih-y2k/wedeploy-gosocketio
+go get github.com/thetatoken/theta/crypto/bls
 
 # Fix mul_arm64.h
 rm ./crypto/bn256/cloudflare/mul_arm64.h

--- a/docs/COMPILE_ARM64.md
+++ b/docs/COMPILE_ARM64.md
@@ -1,0 +1,69 @@
+# Install Guardian Node from Source Code
+
+The script was tested on the following device:
+* Raspberry Pi OS 64 bits, Kernel Version 5.10, Debian version 11 (bullseye)
+* Raspberry Pi 4 4GB RAM
+
+## Install Go 1.14.2
+
+Install Go and set environment variables `GOPATH` , `GOBIN`, and `PATH` following the commands below. The current code base should compile with **Go 1.14.2** on a ARM64 based architecture. Below are the steps to install Go 1.14.2 and setup the environments on Ubuntu.
+
+```
+sudo apt-get update
+sudo apt-get install build-essential
+sudo apt-get install gcc
+sudo apt-get install make
+sudo apt install libstdc++-9-dev
+sudo wget https://go.dev/dl/go1.14.2.linux-arm64.tar.gz
+sudo tar -C /usr/local -xzf go1.14.2.linux-arm64.tar.gz
+echo 'export GOROOT=/usr/local/go' >> ~/.bashrc
+echo 'export GOPATH=$HOME/go' >> ~/.bashrc
+echo 'export PATH=$PATH:$GOROOT/bin:$GOPATH/bin' >> ~/.bashrc
+echo 'export THETA_HOME=$GOPATH/src/github.com/thetatoken/theta' >> ~/.bashrc
+source ~/.bashrc
+```
+
+## Checkout, fix dependences, and compile the Theta Guardian source code
+
+Clone the `release` branch of the Theta Ledger repo https://github.com/thetatoken/theta-protocol-ledger into your `$GOPATH` with the following command. The path should look like this: `$GOPATH/src/github.com/thetatoken/theta`
+
+```
+git clone --branch release https://github.com/thetatoken/theta-protocol-ledger.git $GOPATH/src/github.com/thetatoken/theta
+```
+
+Then, we have to fix the package dependences for ARM64:
+```
+# Fix Go dependences
+cd $THETA_HOME
+sed 's/v0.0.0-20200107021104-147ed25f233e/v0.0.0-20220216073600-600054663ec1/' go.mod > aux_file
+sed 's/github.com\/wedeploy\/gosocketio v0.0.7-beta/github.com\/googollee\/go-socket.io v1.6.1/' aux_file > aux_file2
+rm go.mod
+cp aux_file2 go.mod
+rm aux_file aux_file2
+
+# Fix mul_arm64.h
+rm ./crypto/bn256/cloudflare/mul_arm64.h
+wget -O ./crypto/bn256/cloudflare/mul_arm64.h https://raw.githubusercontent.com/cloudflare/bn256/master/mul_arm64.h
+```
+
+Finally, we build the binaries:
+```
+cd $THETA_HOME
+export GO111MODULE=on
+make install
+```
+
+## Download necessary data for the Guardian Node
+
+```
+cd $THETA_HOME
+mkdir -p ../guardian_mainnet/node
+curl -k --output ../guardian_mainnet/node/snapshot `curl -k https://mainnet-data.thetatoken.org/snapshot`
+curl -k --output ../guardian_mainnet/node/config.yaml `curl -k 'https://mainnet-data.thetatoken.org/config?is_guardian=true'`
+```
+
+## Launch the node and stake
+
+Please continue with the instructions [here](./CLI.md#launch-the-guardian-node).
+
+


### PR DESCRIPTION
Add documentation for ARM64, tested on a Raspberry Pi 4 4GB, using Raspberry OS 64 bits.
This guide is based on #1. Resolves #3, resolves thetatoken/theta-protocol-ledger#86.

The guide is only for 64 bit OS. I can't make it work for 32 bits.

![Captura de pantalla de 2022-03-02 17-12-41](https://user-images.githubusercontent.com/18518739/156546023-1831833b-f9f3-4849-939b-45d71e0593dd.png)

![Captura de pantalla de 2022-03-02 22-45-54](https://user-images.githubusercontent.com/18518739/156546063-d15310ff-4edd-4b34-9504-5bb48e6a4697.png)

![Captura de pantalla de 2022-03-02 22-46-05](https://user-images.githubusercontent.com/18518739/156546092-329d67b7-9f4d-480d-9906-01ae9fa92cce.png)

![Captura de pantalla de 2022-03-02 23-03-22](https://user-images.githubusercontent.com/18518739/156546114-7565144e-6740-46bc-b5e9-dc84fe1626df.png)

Resource usage for Raspberry Pi 4 4GB:
![Captura de pantalla de 2022-03-02 23-14-55](https://user-images.githubusercontent.com/18518739/156546179-d0072935-bf71-43e4-81cd-a0af6d75fab3.png)


Binaries in .zip files (big sizes):
* [dump_storeview.zip](https://github.com/thetatoken/guardian-mainnet-guide/files/8177430/dump_storeview.zip)
* [encrypt_sk.zip](https://github.com/thetatoken/guardian-mainnet-guide/files/8177432/encrypt_sk.zip)
* [generate_genesis.zip](https://github.com/thetatoken/guardian-mainnet-guide/files/8177433/generate_genesis.zip)
* [hex_obj_parser.zip](https://github.com/thetatoken/guardian-mainnet-guide/files/8177434/hex_obj_parser.zip)
* [import_chain.zip](https://github.com/thetatoken/guardian-mainnet-guide/files/8177435/import_chain.zip)
* [inspect_data.zip](https://github.com/thetatoken/guardian-mainnet-guide/files/8177436/inspect_data.zip)
* [query_db.zip](https://github.com/thetatoken/guardian-mainnet-guide/files/8177437/query_db.zip)
* [sign_hex_msg.zip](https://github.com/thetatoken/guardian-mainnet-guide/files/8177438/sign_hex_msg.zip)
* [thetacli.zip](https://github.com/thetatoken/guardian-mainnet-guide/files/8177440/thetacli.zip)
* [theta.zip](https://github.com/thetatoken/guardian-mainnet-guide/files/8177441/theta.zip)





